### PR TITLE
to enable ios 10's new function (notification service extension)

### DIFF
--- a/lib/apns_gatling/message.rb
+++ b/lib/apns_gatling/message.rb
@@ -7,7 +7,7 @@ module ApnsGatling
     MAXIMUM_PAYLOAD_SIZE = 4096
 
     attr_reader :token
-    attr_accessor :alert, :badge, :sound, :content_available, :category, :custom_payload, :thread_id
+    attr_accessor :alert, :badge, :sound, :content_available, :mutable_content, :category, :custom_payload, :thread_id
     attr_accessor :apns_id, :expiration, :priority, :topic, :apns_collapse_id
 
    def initialize(token)
@@ -31,6 +31,7 @@ module ApnsGatling
      aps.merge!(sound: sound) if sound
      aps.merge!(category: category) if category
      aps.merge!('content-available' => content_available) if content_available
+     aps.merge!('mutable-content' => mutable_content) if mutable_content
      aps.merge!('thread-id' => thread_id) if thread_id
 
      message = {aps: aps}


### PR DESCRIPTION
Hi. Thank you for providing a good gem. It helped me a lot.

By the way, to use iOS 10's new function named `Notification Service Extension`, which handle push with image and movie, 
we need to send `mutable-content: 1` as a key of apns payload. Like similar to `content-available: 1`.
I already tried it under an environment of production, and I checked that it works.

(please check the detail of the new function `Notification Service Extension` by this article
https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension)