### PR TITLE
Local connection error

### DIFF
--- a/lib/apns_gatling/apns_client.rb
+++ b/lib/apns_gatling/apns_client.rb
@@ -54,7 +54,7 @@ module ApnsGatling
 
     def connection_error(e)
       @mutex.synchronize do 
-        @requests.values do | request | 
+        @requests.values.map do | request | 
           block = request[:block]
           response = request[:response]
           if block && response

--- a/lib/apns_gatling/request.rb
+++ b/lib/apns_gatling/request.rb
@@ -1,9 +1,10 @@
 module ApnsGatling
   class Request
-    attr_reader :host, :path, :auth_token, :headers, :data
+    attr_reader :id, :host, :path, :auth_token, :headers, :data
 
     def initialize(message, auth_token, host)
       path = "/3/device/#{message.token}"
+      @id = message.token + message.apns_id
       @path = path
       @auth_token = auth_token
       @headers = headers_from message, auth_token, host, path

--- a/lib/apns_gatling/request.rb
+++ b/lib/apns_gatling/request.rb
@@ -4,7 +4,7 @@ module ApnsGatling
 
     def initialize(message, auth_token, host)
       path = "/3/device/#{message.token}"
-      @id = message.token + message.apns_id
+      @id = message.apns_id
       @path = path
       @auth_token = auth_token
       @headers = headers_from message, auth_token, host, path

--- a/lib/apns_gatling/response.rb
+++ b/lib/apns_gatling/response.rb
@@ -4,10 +4,13 @@ module ApnsGatling
   class Response
     # See: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
     attr_accessor :headers, :data
+    attr_reader :message
 
-    def initialize()
+    def initialize(message)
       @headers = {}
       @data = ''
+      @message = message 
+      @internal_error = nil
     end
 
     def status
@@ -22,7 +25,12 @@ module ApnsGatling
       JSON.parse(@data) rescue @data
     end
 
+    def error_with(reason)
+      @internal_error = {reason: reason, 'apns-id': @message.apns_id, status: '0'}
+    end
+
     def error
+      return @internal_error if @internal_error
       if status != '200'
         e = {}
         e.merge!(status: @headers[':status']) if @headers[':status']


### PR DESCRIPTION
fix #3 
` t.abort_on_exception = true` it's a terrible solution to interrupt  push message progress when socket closed or failed.
Now, I think the socket raised error is also a connection error, so this error should be delivered to `client.push` callback as a part of response.

 